### PR TITLE
feat(auth): red login/signup

### DIFF
--- a/backend/producer/src/application/ports/IPasswordHasher.ts
+++ b/backend/producer/src/application/ports/IPasswordHasher.ts
@@ -1,0 +1,5 @@
+// Contrato para adaptar librerías de cifrado usadas en login/signup.
+export interface IPasswordHasher {
+  hash(value: string): Promise<string>;
+  compare(candidate: string, hashed: string): Promise<boolean>;
+}

--- a/backend/producer/src/application/use-cases/login.use-case.ts
+++ b/backend/producer/src/application/use-cases/login.use-case.ts
@@ -1,0 +1,30 @@
+import { IUserRepository } from '../../domain/ports/IUserRepository';
+import { IPasswordHasher } from '../ports/IPasswordHasher';
+
+// Datos necesarios para intentar el inicio de sesión.
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+// Servicio que expone la generación de tokens firmados.
+export interface ITokenService {
+  generateToken(payload: Record<string, unknown>): string;
+}
+
+// Dependencias necesarias para ejecutar el flujo de login.
+export interface LoginDependencies {
+  userRepository: IUserRepository;
+  passwordHasher: IPasswordHasher;
+  tokenService: ITokenService;
+}
+
+// Maneja la autenticación de usuarios validando credenciales y emitiendo tokens.
+export class LoginUseCase {
+  constructor(private readonly deps: LoginDependencies) {}
+
+  // Ejecuta el flujo de login, usando los adapters inyectados.
+  async execute(credentials: LoginCredentials): Promise<string> {
+    throw new Error('Login flow not implemented yet');
+  }
+}

--- a/backend/producer/src/application/use-cases/signup.use-case.ts
+++ b/backend/producer/src/application/use-cases/signup.use-case.ts
@@ -1,0 +1,24 @@
+import { IUserRepository } from '../../domain/ports/IUserRepository';
+import { IPasswordHasher } from '../ports/IPasswordHasher';
+
+// Datos mínimos para registrar un nuevo usuario.
+export interface SignupCredentials {
+  email: string;
+  password: string;
+}
+
+// Dependencias inyectadas para el flujo de registro.
+export interface SignupDependencies {
+  userRepository: IUserRepository;
+  passwordHasher: IPasswordHasher;
+}
+
+// Orquesta la creación de nuevos usuarios asegurando datos válidos.
+export class SignupUseCase {
+  constructor(private readonly deps: SignupDependencies) {}
+
+  // Ejecuta el registro: verifica unicidad, cifra la contraseña y persiste el usuario.
+  async execute(credentials: SignupCredentials): Promise<string> {
+    throw new Error('Signup flow not implemented yet');
+  }
+}

--- a/backend/producer/src/domain/ports/IUserRepository.ts
+++ b/backend/producer/src/domain/ports/IUserRepository.ts
@@ -1,0 +1,13 @@
+// Representa un usuario persistido y sus campos mínimos de autenticación.
+export interface IUserRecord {
+  id: string;
+  email: string;
+  passwordHash: string;
+  isActive: boolean;
+}
+
+// Puerto para desacoplar lógica de persistencia de usuarios.
+export interface IUserRepository {
+  findByEmail(email: string): Promise<IUserRecord | null>;
+  create(params: { email: string; passwordHash: string }): Promise<IUserRecord>;
+}

--- a/backend/producer/test/application/auth/login.use-case.spec.ts
+++ b/backend/producer/test/application/auth/login.use-case.spec.ts
@@ -1,0 +1,58 @@
+import {
+  LoginCredentials,
+  LoginUseCase,
+  LoginDependencies,
+  ITokenService,
+} from '../../../src/application/use-cases/login.use-case';
+import { IUserRecord, IUserRepository } from '../../../src/domain/ports/IUserRepository';
+import { IPasswordHasher } from '../../../src/application/ports/IPasswordHasher';
+
+// Valida el contrato esperado para el caso de uso de login antes de implementarlo.
+describe('LoginUseCase (red tests)', () => {
+  const credentials: LoginCredentials = { email: 'luis@example.com', password: 'secret' };
+  const storedUser: IUserRecord = {
+    id: 'user-1',
+    email: credentials.email,
+    passwordHash: '$argon2id$secret',
+    isActive: true,
+  };
+
+  let repository: jest.Mocked<IUserRepository>;
+  let passwordHasher: jest.Mocked<IPasswordHasher>;
+  let tokenService: jest.Mocked<ITokenService>;
+  let dependencies: LoginDependencies;
+
+  beforeEach(() => {
+    repository = { findByEmail: jest.fn(), create: jest.fn() } as jest.Mocked<IUserRepository>;
+    passwordHasher = { hash: jest.fn(), compare: jest.fn() } as jest.Mocked<IPasswordHasher>;
+    tokenService = { generateToken: jest.fn() } as jest.Mocked<ITokenService>;
+    dependencies = { userRepository: repository, passwordHasher, tokenService };
+  });
+
+  it('should fail when the user is missing', async () => {
+    repository.findByEmail.mockResolvedValue(null);
+    const useCase = new LoginUseCase(dependencies);
+
+    await expect(useCase.execute(credentials)).rejects.toThrow('User not found');
+    expect(repository.findByEmail).toHaveBeenCalledWith(credentials.email);
+  });
+
+  it('should fail when the password does not match', async () => {
+    repository.findByEmail.mockResolvedValue(storedUser);
+    passwordHasher.compare.mockResolvedValue(false);
+    const useCase = new LoginUseCase(dependencies);
+
+    await expect(useCase.execute(credentials)).rejects.toThrow('Invalid credentials');
+    expect(passwordHasher.compare).toHaveBeenCalledWith(credentials.password, storedUser.passwordHash);
+  });
+
+  it('should return a token when credentials are valid', async () => {
+    repository.findByEmail.mockResolvedValue(storedUser);
+    passwordHasher.compare.mockResolvedValue(true);
+    tokenService.generateToken.mockReturnValue('valid-token');
+    const useCase = new LoginUseCase(dependencies);
+
+    await expect(useCase.execute(credentials)).resolves.toBe('valid-token');
+    expect(tokenService.generateToken).toHaveBeenCalled();
+  });
+});

--- a/backend/producer/test/application/auth/signup.use-case.spec.ts
+++ b/backend/producer/test/application/auth/signup.use-case.spec.ts
@@ -1,0 +1,47 @@
+import { IUserRecord, IUserRepository } from '../../../src/domain/ports/IUserRepository';
+import { IPasswordHasher } from '../../../src/application/ports/IPasswordHasher';
+import { SignupCredentials, SignupDependencies, SignupUseCase } from '../../../src/application/use-cases/signup.use-case';
+
+// Asegura que el contrato de signup lanza los errores esperados antes de implementarlo.
+describe('SignupUseCase (red tests)', () => {
+  const credentials: SignupCredentials = { email: 'luis@example.com', password: 'secret' };
+  const hashedSecret = '$argon2id$hashed-secret';
+  const createdUser: IUserRecord = {
+    id: 'user-2',
+    email: credentials.email,
+    passwordHash: hashedSecret,
+    isActive: true,
+  };
+
+  let repository: jest.Mocked<IUserRepository>;
+  let passwordHasher: jest.Mocked<IPasswordHasher>;
+  let dependencies: SignupDependencies;
+
+  beforeEach(() => {
+    repository = { findByEmail: jest.fn(), create: jest.fn() } as jest.Mocked<IUserRepository>;
+    passwordHasher = { hash: jest.fn(), compare: jest.fn() } as jest.Mocked<IPasswordHasher>;
+    dependencies = { userRepository: repository, passwordHasher };
+  });
+
+  it('should error when the email is already registered', async () => {
+    repository.findByEmail.mockResolvedValue(createdUser);
+    const useCase = new SignupUseCase(dependencies);
+
+    await expect(useCase.execute(credentials)).rejects.toThrow('Email already in use');
+    expect(repository.findByEmail).toHaveBeenCalledWith(credentials.email);
+  });
+
+  it('should return the new user id once signup data is valid', async () => {
+    repository.findByEmail.mockResolvedValue(null);
+    passwordHasher.hash.mockResolvedValue(hashedSecret);
+    repository.create.mockResolvedValue(createdUser);
+    const useCase = new SignupUseCase(dependencies);
+
+    await expect(useCase.execute(credentials)).resolves.toBe(createdUser.id);
+    expect(passwordHasher.hash).toHaveBeenCalledWith(credentials.password);
+    expect(repository.create).toHaveBeenCalledWith({
+      email: credentials.email,
+      passwordHash: hashedSecret,
+    });
+  });
+});


### PR DESCRIPTION
## Resumen\n- agrega los puertos e interfaces necesarios para login y signup\n- deja los casos de uso en fase red mientras las pruebas describen los errores esperados\n\n## Testing\n- CI=1 npx jest --runInBand test/application/auth/login.use-case.spec.ts test/application/auth/signup.use-case.spec.ts (deben fallar porque los use case lanzan errores de placeholder)