### PR TITLE
docs: simplify test plan and align with CI

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -2,9 +2,9 @@
 
 **Proyecto:** Sistema de turnos EPS  
 **Módulos:** `frontend/` — feature/authentication | `backend/producer/` — API y aceptación  
-**Responsable:** David Angarita  
-**Fecha:** 2026-03-05  
-**Versión:** 2.0
+**Responsable:** David Angarita y Duver Betancur  
+**Fecha:** 2026-03-09  
+**Versión:** 3.0
 
 ---
 
@@ -42,29 +42,9 @@ El flujo de autenticación del frontend cubre tres responsabilidades principales
 
 ---
 
-## 2. JUSTIFICACIÓN TEÓRICA: 7 PRINCIPIOS DEL TESTING
+## 2. ESTRATEGIA DE PRUEBAS
 
-La estrategia de pruebas de esta feature se fundamenta en los 7 principios del testing. A continuación se describe cómo cada principio guía las decisiones tomadas:
-
-**Principio 1 — Las pruebas muestran la presencia de defectos, no su ausencia.** Las suites de pruebas de `SignUpForm` y `AuthProvider` cubren los caminos conocidos de falla, pero no garantizan que el sistema esté libre de defectos. Por eso se combina cobertura de ramas con revisión humana de los casos límite.
-
-**Principio 2 — Las pruebas exhaustivas son imposibles.** No se prueban todas las combinaciones posibles de email y contraseña. En cambio, se aplican técnicas de partición de equivalencia (entradas válidas, inválidas y vacías) para maximizar la cobertura con el menor número de casos.
-
-**Principio 3 — Las pruebas tempranas ahorran tiempo y dinero (Shift-Left).** Los tests de componente e integración se ejecutan en el pipeline CI antes de que cualquier rama llegue a `develop`. Si una prueba del `AuthProvider` falla, el merge queda bloqueado automáticamente.
-
-**Principio 4 — Agrupación de defectos.** La lógica crítica se concentra en `AuthProvider` (gestión de estado) y `HttpAuthAdapter` (comunicación con API). Por eso estas clases tienen la mayor densidad de casos de prueba y son las primeras en ejecutarse en el pipeline.
-
-**Principio 5 — La paradoja del pesticida.** Los mocks del `mockAuthService` se renuevan conforme evolucionan los contratos del backend. Mantener mocks desactualizados crea una falsa sensación de seguridad. Se exige que los mocks reflejen exactamente la forma del `AuthService` port.
-
-**Principio 6 — Las pruebas dependen del contexto.** Esta feature es de tipo SPA con renderizado del lado del cliente (`"use client"`). Por eso se utiliza `jsdom` como entorno Jest, se mockea `next/navigation` y `sessionStorage`, y las pruebas de infraestructura mockean `fetch` global en lugar de usar un servidor HTTP real.
-
-**Principio 7 — La falacia de la ausencia de errores.** Un 100% de cobertura de líneas no significa que el sistema sea correcto. El `AuthGuard` puede pasar todos sus tests unitarios y aun así fallar si la cookie JWT no se setea correctamente en el flujo real. Por eso se diseñan pruebas de integración que validan el flujo completo sin mocks en las capas de dominio.
-
----
-
-## 3. ESTRATEGIA DE PRUEBAS
-
-### 3.1 Niveles de prueba
+### 2.1 Niveles de prueba
 
 **Pruebas de Componente (Caja Blanca)**  
 Validan la lógica interna de cada unidad de forma aislada. Se conoce la implementación y se prueba el flujo de ramas, estados y efectos secundarios. Se ejecutan con Jest + React Testing Library. Las dependencias externas (`authService`, `router`, `sessionStorage`) se sustituyen por mocks.
@@ -75,10 +55,10 @@ Validan el comportamiento observable del `HttpAuthAdapter` contra los contratos 
 **Pruebas de Aceptación — Gherkin (Caja Negra Declarativa)**  
 Validan el comportamiento del sistema desde la perspectiva del negocio usando sintaxis **Given/When/Then** (patrón Estado-Acción-Estado). Se ejecutan con `cucumber-js` contra la API del Producer mediante `supertest`. Los escenarios son **declarativos**: describen QUÉ debería ocurrir en términos de negocio, sin mencionar clics, campos de formulario ni detalles de implementación. Las dependencias externas (RabbitMQ, MongoDB) se sustituyen por stubs in-memory para garantizar aislamiento y velocidad.
 
-**Justificación del uso de Gherkin (Principio 6 — Contexto):**  
-El contexto del proyecto es un sistema de turnos EPS donde el flujo principal (crear turno, registrar usuario) es un comportamiento de negocio crítico cuya validación no debe depender de la implementación técnica. Gherkin permite expresar estos flujos como escenarios de negocio comprensibles por stakeholders no técnicos, aplicando el **patrón Estado-Acción-Estado**: el Given establece un estado conocido del sistema, el When ejecuta una acción de negocio, y el Then verifica que el sistema transicionó al estado esperado. Esto garantiza que si se refactoriza la implementación interna (ej. cambiar de RabbitMQ a Kafka), los escenarios Gherkin siguen siendo válidos.
+**Uso de Gherkin:**  
+Los escenarios Gherkin se usan para expresar el comportamiento esperado del sistema en lenguaje de negocio. El **Given** define el estado inicial, el **When** ejecuta la acción y el **Then** valida el resultado esperado. Esto permite que el plan se mantenga enfocado en comportamiento funcional y no en detalles de implementación.
 
-### 3.2 Técnicas aplicadas
+### 2.2 Técnicas aplicadas
 
 | Técnica | Nivel | Aplicación |
 | :--- | :--- | :--- |
@@ -89,7 +69,7 @@ El contexto del proyecto es un sistema de turnos EPS donde el flujo principal (c
 | Prueba de contrato | Integración | `HttpAuthAdapter` verifica que los payloads enviados coincidan con la API del backend |
 | BDD Gherkin (Estado-Acción-Estado) | Aceptación | Escenarios declarativos de creación de turno y registro de usuario vía API |
 
-### 3.3 Ciclos de ejecución
+### 2.3 Ciclos de ejecución
 
 1. **Unit / Component (CI — cada PR):** Ejecución automática de toda la suite Jest al abrir un Pull Request. Bloquea el merge si hay fallos.
 2. **Integration (CI — cada PR hacia develop):** Job diferenciado en el pipeline que ejecuta únicamente los tests de `infrastructure/` con `testPathPattern=infrastructure`.
@@ -98,7 +78,7 @@ El contexto del proyecto es un sistema de turnos EPS donde el flujo principal (c
 
 ---
 
-## 4. HISTORIAS DE USUARIO Y CRITERIOS DE ACEPTACIÓN
+## 3. HISTORIAS DE USUARIO Y CRITERIOS DE ACEPTACIÓN
 
 ### HU-AUTH-01: Registro de usuario
 
@@ -143,7 +123,7 @@ El contexto del proyecto es un sistema de turnos EPS donde el flujo principal (c
 
 ---
 
-## 5. DISEÑO DE CASOS DE PRUEBA
+## 4. DISEÑO DE CASOS DE PRUEBA
 
 ### Suite 1 — SignUpForm (Caja Blanca — Componente)
 
@@ -274,13 +254,7 @@ Feature: Registro de usuario interno vía API
 | TC-GU-02 | Correo duplicado | Usuario ya registrado con ese correo | Registrar otro con mismo correo | Registro rechazado, error "Email already in use" |
 | TC-GU-03 | Login post-registro | Usuario registrado previamente | Iniciar sesión con credenciales correctas | Autenticación exitosa, token válido |
 
-### Paradoja del pesticida aplicada a Gherkin (Principio 5)
-
-Los escenarios Gherkin se diseñan para evolucionar con el negocio. Si el sistema incorpora nuevas reglas (ej. límite de turnos por cédula, validación de horario), los escenarios `Given` deben ampliarse para reflejar el nuevo estado inicial. Mantener escenarios estáticos genera una falsa sensación de cobertura — el "pesticida" deja de ser efectivo contra los nuevos defectos.
-
----
-
-## 6. REQUERIMIENTOS
+## 5. REQUERIMIENTOS
 
 1. Node.js 20+ y dependencias instaladas (`npm install` en `frontend/`).
 2. Acceso al repositorio con permisos de lectura/escritura para el pipeline CI.
@@ -290,7 +264,7 @@ Los escenarios Gherkin se diseñan para evolucionar con el negocio. Si el sistem
 
 ---
 
-## 7. MATRIZ DE RIESGOS
+## 6. MATRIZ DE RIESGOS
 
 | Historia de Usuario | Probabilidad | Impacto | Riesgo (P×I) | Mitigación |
 | :--- | :---: | :---: | :---: | :--- |
@@ -306,55 +280,8 @@ Los escenarios Gherkin se diseñan para evolucionar con el negocio. Si el sistem
 
 ---
 
-## 8. DISTINCIÓN TÉCNICA: CAJA BLANCA vs CAJA NEGRA vs GHERKIN DECLARATIVO
+## 7. NOTA FINAL
 
-**Pruebas de Caja Blanca (Suites 1–4)**  
-Se conoce la implementación interna. Los tests importan directamente los componentes y providers, inspeccionan el árbol del DOM resultante, verifican que se llamaron funciones específicas (ej. `router.push`, `sessionStorage.setItem`) y validan transiciones de estado interno. Las dependencias (`authService`, `useRouter`) son mocks controlados que permiten forzar cualquier escenario.
+Este test plan se enfoca en cobertura funcional, diseño de casos de prueba y planificación de escenarios en Gherkin.
 
-**Pruebas de Caja Negra (Suite 5 — HttpAuthAdapter)**  
-Se valida el comportamiento observable del adaptador sin conocer cómo el servidor procesa la solicitud. El adaptador recibe una respuesta simulada del servidor (mock de `fetch`) y se verifica únicamente lo que produce hacia afuera: el `AuthResult` retornado, las cookies seteadas y los payloads enviados. No se accede a variables internas del adaptador ni se verifica su lógica de flujo de control; solo sus entradas y salidas.
-
-**Pruebas Gherkin Declarativas (Suites 6–7 — Aceptación)**  
-Elevan la Caja Negra al nivel de negocio. Los escenarios están escritos en lenguaje natural siguiendo el **patrón Estado-Acción-Estado** (Given/When/Then). Se ejecutan contra la API real del Producer vía HTTP (`supertest`), sin conocimiento de la implementación interna. Las dependencias externas (RabbitMQ, MongoDB) se sustituyen por stubs para garantizar determinismo, pero la capa HTTP, validación de DTOs (class-validator) y lógica de use cases se ejecutan de forma real —exactamente como en producción—. Esto las convierte en pruebas de Caja Negra de alto nivel donde **el lenguaje del test es el lenguaje del negocio**, no el del código.
-
----
-
-## 9. EVIDENCIA DE EJECUCIÓN DEL PIPELINE CI/CD
-
-Las siguientes capturas demuestran la ejecución exitosa del pipeline en GitHub Actions en todas sus etapas.
-
-### 9.1 Pipeline completo (vista general)
-
-Todos los jobs ejecutados en verde: Lint & Typecheck → Component Tests → Integration Tests → Docker Build & Security Scan.
-
-![Pipeline completo en verde](docs/Pipeline_success.png)
-
-### 9.2 Job 1 — Lint & Typecheck
-
-Verificación estática de tipos (`tsc --noEmit`) y linting sobre los tres módulos (`frontend`, `producer`, `consumer`) sin errores.
-
-![Lint y Typecheck exitoso](docs/Lint_type_success.png)
-
-### 9.3 Job 2 — Component Tests (Caja Blanca)
-
-Ejecución de pruebas de componente (providers, components, hooks, app en frontend; application, domain, presentation en producer y consumer). Todos los casos pasan.
-
-![Pruebas de componente exitosas](docs/Component_test_success.png)
-
-### 9.4 Job 3 — Integration Tests (Caja Negra)
-
-Ejecución de pruebas de infraestructura (`HttpAuthAdapter`, adaptadores de RabbitMQ/MongoDB) y escenarios Gherkin (`cucumber-js`) contra la API del Producer. Todos los escenarios pasan.
-
-![Pruebas de integración y aceptación exitosas](docs/Integration_test_success.png)
-
-### 9.5 Job 4 — Docker Build & Security Scan (Trivy)
-
-Construcción de las tres imágenes Docker (`frontend:ci`, `producer:ci`, `consumer:ci`) y escaneo de vulnerabilidades con Trivy. Sin hallazgos CRITICAL que bloqueen el merge.
-
-![Docker build y escaneo de seguridad exitoso](docs/Docker_security_success.png)
-
-### 9.6 Cobertura de pruebas — Frontend
-
-Reporte de cobertura de Jest para el módulo `frontend/`. Las suites de autenticación (SignUpForm, SignInForm, AuthGuard, AuthProvider, HttpAuthAdapter) alcanzan la cobertura objetivo.
-
-![Cobertura frontend](docs/frontend_coverage.png)
+La evidencia de ejecución del pipeline, capturas y reportes de cobertura se mantiene fuera de este documento.


### PR DESCRIPTION
$## Resumen\n- simplifica el test plan eliminando contenido no esencial\n- mantiene el enfoque en cobertura funcional y escenarios Gherkin\n- deja explícito que la evidencia del pipeline se gestiona por separado\n\n## Contexto\nSe ajusta la documentación para que el plan quede más enfocado en planificación y validación funcional.