### PR TITLE
refactor(ci): split workflow jobs by domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,99 +11,280 @@ on:
 # Pipeline multinivel — Shift-Left Quality
 #
 # Flujo de ejecución:
-#   lint-and-typecheck
-#        ├──► component-tests  (Caja Blanca)
-#        └──► integration-tests (Caja Negra)
-#                    └──► docker-security-scan
+#   detect-changes
+#        ├──► lint-* / typecheck-*
+#        │          └──► component-tests-* / integration-tests-*
+#        │                               └──► acceptance-tests-producer
+#        └──────────────────────────────────────────► docker-security-scan-*
+#
+# Se ejecuta por dominio (frontend / producer / consumer) para reducir
+# tiempos y aislar fallos por componente.
 # ─────────────────────────────────────────────────────────────────────────────
 
 jobs:
 
-  # ── Job 1: Verificación estática ──────────────────────────────────────────
-  lint-and-typecheck:
-    name: Lint & Typecheck
+  # ── Job 1: Detección de cambios ───────────────────────────────────────────
+  detect-changes:
+    name: Detect changed areas
     runs-on: ubuntu-latest
+
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      producer: ${{ steps.filter.outputs.producer }}
+      consumer: ${{ steps.filter.outputs.consumer }}
+      shared: ${{ steps.filter.outputs.shared }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            shared:
+              - '.github/workflows/**'
+              - 'docker-compose.yml'
+            frontend:
+              - 'frontend/**'
+            producer:
+              - 'backend/producer/**'
+            consumer:
+              - 'backend/consumer/**'
+
+  # ── Job 2: Lint por dominio ───────────────────────────────────────────────
+  lint-frontend:
+    name: Lint frontend
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install dependencies
-        run: |
-          bun install --cwd frontend
-          bun install --cwd backend/producer
-          bun install --cwd backend/consumer
+      - name: Install frontend dependencies
+        run: bun install --cwd frontend --frozen-lockfile
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: bun run lint:ci
+
+  lint-producer:
+    name: Lint producer
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install producer dependencies
+        run: bun install --cwd backend/producer --frozen-lockfile
+
+      - name: Lint producer
+        working-directory: backend/producer
+        run: bun run lint:ci
+
+  lint-consumer:
+    name: Lint consumer
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.consumer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install consumer dependencies
+        run: bun install --cwd backend/consumer --frozen-lockfile
+
+      - name: Lint consumer
+        working-directory: backend/consumer
+        run: bun run lint:ci
+
+  # ── Job 3: Typecheck por dominio ──────────────────────────────────────────
+  typecheck-frontend:
+    name: Typecheck frontend
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: bun install --cwd frontend --frozen-lockfile
 
       - name: Typecheck frontend
         working-directory: frontend
         run: bun run typecheck
 
+  typecheck-producer:
+    name: Typecheck producer
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install producer dependencies
+        run: bun install --cwd backend/producer --frozen-lockfile
+
       - name: Typecheck producer
         working-directory: backend/producer
         run: bun run typecheck
+
+  typecheck-consumer:
+    name: Typecheck consumer
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.consumer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install consumer dependencies
+        run: bun install --cwd backend/consumer --frozen-lockfile
 
       - name: Typecheck consumer
         working-directory: backend/consumer
         run: bun run typecheck
 
-  # ── Job 2: Pruebas de Componente — Caja Blanca ────────────────────────────
-  component-tests:
-    name: Component Tests (White-Box)
+  # ── Job 4: Pruebas de componente — Caja Blanca ────────────────────────────
+  component-tests-frontend:
+    name: Component tests frontend
     runs-on: ubuntu-latest
-    needs: lint-and-typecheck
+    needs: [detect-changes, lint-frontend, typecheck-frontend]
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install dependencies
-        run: |
-          bun install --cwd frontend
-          bun install --cwd backend/producer
-          bun install --cwd backend/consumer
+      - name: Install frontend dependencies
+        run: bun install --cwd frontend --frozen-lockfile
 
       - name: "[Frontend] Component tests — providers, components, hooks, app"
         working-directory: frontend
         run: bun run test -- --testPathPatterns="(components|providers|hooks|app)" --passWithNoTests
 
-      - name: "[Producer] Component tests — application, domain, presentation"
-        working-directory: backend/producer
-        run: bun run test -- --testPathPatterns="(application|domain|presentation)" --passWithNoTests
-
-      - name: "[Consumer] Component tests — application, domain, presentation"
-        working-directory: backend/consumer
-        run: bun run test -- --testPathPatterns="(application|domain|presentation)" --passWithNoTests
-
-  # ── Job 3: Pruebas de Integración — Caja Negra ───────────────────────────
-  integration-tests:
-    name: Integration Tests (Black-Box)
+  component-tests-producer:
+    name: Component tests producer
     runs-on: ubuntu-latest
-    needs: lint-and-typecheck
+    needs: [detect-changes, lint-producer, typecheck-producer]
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install dependencies
-        run: |
-          bun install --cwd frontend
-          bun install --cwd backend/producer
-          bun install --cwd backend/consumer
+      - name: Install producer dependencies
+        run: bun install --cwd backend/producer --frozen-lockfile
+
+      - name: "[Producer] Component tests — application, domain, presentation"
+        working-directory: backend/producer
+        run: bun run test -- --testPathPatterns="(application|domain|presentation)" --passWithNoTests
+
+  component-tests-consumer:
+    name: Component tests consumer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint-consumer, typecheck-consumer]
+    if: ${{ needs.detect-changes.outputs.consumer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install consumer dependencies
+        run: bun install --cwd backend/consumer --frozen-lockfile
+
+      - name: "[Consumer] Component tests — application, domain, presentation"
+        working-directory: backend/consumer
+        run: bun run test -- --testPathPatterns="(application|domain|presentation)" --passWithNoTests
+
+  # ── Job 5: Pruebas de integración — Caja Negra ────────────────────────────
+  integration-tests-frontend:
+    name: Integration tests frontend
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint-frontend, typecheck-frontend]
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: bun install --cwd frontend --frozen-lockfile
 
       - name: "[Frontend] Integration tests — infrastructure adapters"
         working-directory: frontend
         run: bun run test -- --testPathPatterns="infrastructure" --passWithNoTests
 
+  integration-tests-producer:
+    name: Integration tests producer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint-producer, typecheck-producer]
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install producer dependencies
+        run: bun install --cwd backend/producer --frozen-lockfile
+
       - name: "[Producer] Integration tests — infrastructure"
         working-directory: backend/producer
         run: bun run test -- --testPathPatterns="infrastructure" --passWithNoTests
 
+  integration-tests-consumer:
+    name: Integration tests consumer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint-consumer, typecheck-consumer]
+    if: ${{ needs.detect-changes.outputs.consumer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install consumer dependencies
+        run: bun install --cwd backend/consumer --frozen-lockfile
+
       - name: "[Consumer] Integration tests — infrastructure"
         working-directory: backend/consumer
         run: bun run test -- --testPathPatterns="infrastructure" --passWithNoTests
+
+  acceptance-tests-producer:
+    name: Acceptance tests producer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint-producer, typecheck-producer, integration-tests-producer]
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install producer dependencies
+        run: bun install --cwd backend/producer --frozen-lockfile
 
       # ⚕️ HUMAN CHECK - Pruebas de Caja Negra con Gherkin (Given/When/Then)
       # Ejecutan escenarios declarativos contra la API usando cucumber-js
@@ -111,57 +292,75 @@ jobs:
         working-directory: backend/producer
         run: bun run test:acceptance
 
-  # ── Job 4: Build Docker + Escaneo de seguridad ───────────────────────────
-  docker-security-scan:
-    name: Docker Build & Security Scan
+  # ── Job 6: Build Docker + escaneo de seguridad por dominio ───────────────
+  docker-security-scan-frontend:
+    name: Docker build & scan frontend
     runs-on: ubuntu-latest
-    needs: [component-tests, integration-tests]
+    needs: [detect-changes, component-tests-frontend, integration-tests-frontend]
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Build frontend image
-        id: build_frontend
         run: docker build -t frontend:ci ./frontend
 
-      # ⚕️ HUMAN CHECK - El context del build es ./backend (no ./backend/producer)
-      # porque el Dockerfile usa COPY producer/package*.json desde la raíz del context
-      - name: Build producer image
-        id: build_producer
-        run: docker build -t producer:ci -f backend/producer/Dockerfile ./backend
-
-      - name: Build consumer image
-        id: build_consumer
-        run: docker build -t consumer:ci -f backend/consumer/Dockerfile ./backend
-
       - name: Install Trivy scanner
-        if: always()
-        id: install_trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
       # ⚕️ HUMAN CHECK - SAST Shift-Left: exit-code 1 en CRITICAL bloquea el merge
       # HIGH se reporta pero no bloquea (exit-code 0) para evitar falsos positivos
       - name: Scan frontend image (CRITICAL = block)
-        if: always() && steps.build_frontend.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 1 --severity CRITICAL --format table frontend:ci
 
       - name: Scan frontend image (HIGH = report)
-        if: always() && steps.build_frontend.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 0 --severity HIGH --format table frontend:ci
 
+  docker-security-scan-producer:
+    name: Docker build & scan producer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, component-tests-producer, integration-tests-producer, acceptance-tests-producer]
+    if: ${{ needs.detect-changes.outputs.producer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ⚕️ HUMAN CHECK - El context del build es ./backend (no ./backend/producer)
+      # porque el Dockerfile usa COPY producer/package*.json desde la raíz del context
+      - name: Build producer image
+        run: docker build -t producer:ci -f backend/producer/Dockerfile ./backend
+
+      - name: Install Trivy scanner
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+      # ⚕️ HUMAN CHECK - SAST Shift-Left: exit-code 1 en CRITICAL bloquea el merge
+      # HIGH se reporta pero no bloquea (exit-code 0) para evitar falsos positivos
       - name: Scan producer image (CRITICAL = block)
-        if: always() && steps.build_producer.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 1 --severity CRITICAL --format table producer:ci
 
       - name: Scan producer image (HIGH = report)
-        if: always() && steps.build_producer.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 0 --severity HIGH --format table producer:ci
 
+  docker-security-scan-consumer:
+    name: Docker build & scan consumer
+    runs-on: ubuntu-latest
+    needs: [detect-changes, component-tests-consumer, integration-tests-consumer]
+    if: ${{ needs.detect-changes.outputs.consumer == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build consumer image
+        run: docker build -t consumer:ci -f backend/consumer/Dockerfile ./backend
+
+      - name: Install Trivy scanner
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Scan consumer image (CRITICAL = block)
-        if: always() && steps.build_consumer.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 1 --severity CRITICAL --format table consumer:ci
 
       - name: Scan consumer image (HIGH = report)
-        if: always() && steps.build_consumer.outcome == 'success' && steps.install_trivy.outcome == 'success'
         run: trivy image --exit-code 0 --severity HIGH --format table consumer:ci

--- a/backend/consumer/.eslintrc.cjs
+++ b/backend/consumer/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../eslint.base.cjs');

--- a/backend/consumer/package.json
+++ b/backend/consumer/package.json
@@ -12,6 +12,7 @@
         "start:debug": "nest start --debug --watch",
         "start:prod": "node dist/main",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+        "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
         "typecheck": "tsc --noEmit",
         "test": "jest",
         "test:watch": "jest --watch",

--- a/backend/eslint.base.cjs
+++ b/backend/eslint.base.cjs
@@ -1,0 +1,32 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+    es2021: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  ignorePatterns: ['node_modules/', 'dist/', 'coverage/'],
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
+    ],
+    '@typescript-eslint/no-require-imports': 'off',
+  },
+};

--- a/backend/producer/.eslintrc.cjs
+++ b/backend/producer/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../eslint.base.cjs');

--- a/backend/producer/package.json
+++ b/backend/producer/package.json
@@ -12,6 +12,7 @@
         "start:debug": "nest start --debug --watch",
         "start:prod": "node dist/main",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+        "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
         "typecheck": "tsc --noEmit",
         "test": "jest",
         "test:watch": "jest --watch",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
-import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
   ...nextVitals,

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -13,6 +14,19 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+      "import/no-anonymous-default-export": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "lint:ci": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/frontend/src/__mocks__/styleMock.ts
+++ b/frontend/src/__mocks__/styleMock.ts
@@ -1,1 +1,3 @@
-export default {};
+const styleMock = {};
+
+export default styleMock;

--- a/frontend/src/__tests__/infrastructure/adapters/HttpAuthAdapter.spec.ts
+++ b/frontend/src/__tests__/infrastructure/adapters/HttpAuthAdapter.spec.ts
@@ -167,6 +167,7 @@ describe("HttpAuthAdapter", () => {
 
     it("falls back to 'empleado' when role is not in the map", async () => {
       mockedHttpPost.mockResolvedValue({ success: true, message: "OK" });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await adapter.signUp({ email: "a@b.com", password: "x", name: "Y", role: "unknown" as any });
       expect(mockedHttpPost).toHaveBeenCalledWith(
         expect.any(String),

--- a/frontend/src/components/SignInForm/SignInForm.tsx
+++ b/frontend/src/components/SignInForm/SignInForm.tsx
@@ -16,11 +16,11 @@ export default function SignInForm() {
   const { sanitizer } = useDeps();
   const router = useRouter();
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     const msg = sessionStorage.getItem(SIGNUP_SUCCESS_KEY);
     if (msg) {
       sessionStorage.removeItem(SIGNUP_SUCCESS_KEY);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setToast(msg);
       const id = setTimeout(() => setToast(null), 4000);
       return () => clearTimeout(id);

--- a/frontend/src/components/SignInForm/SignInForm.tsx
+++ b/frontend/src/components/SignInForm/SignInForm.tsx
@@ -20,9 +20,12 @@ export default function SignInForm() {
     const msg = sessionStorage.getItem(SIGNUP_SUCCESS_KEY);
     if (msg) {
       sessionStorage.removeItem(SIGNUP_SUCCESS_KEY);
-      setToast(msg);
-      const id = setTimeout(() => setToast(null), 4000);
-      return () => clearTimeout(id);
+      const displayId = setTimeout(() => setToast(msg), 0);
+      const clearId = setTimeout(() => setToast(null), 4000);
+      return () => {
+        clearTimeout(displayId);
+        clearTimeout(clearId);
+      };
     }
   }, []);
 

--- a/frontend/src/components/SignInForm/SignInForm.tsx
+++ b/frontend/src/components/SignInForm/SignInForm.tsx
@@ -16,16 +16,14 @@ export default function SignInForm() {
   const { sanitizer } = useDeps();
   const router = useRouter();
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     const msg = sessionStorage.getItem(SIGNUP_SUCCESS_KEY);
     if (msg) {
       sessionStorage.removeItem(SIGNUP_SUCCESS_KEY);
-      const displayId = setTimeout(() => setToast(msg), 0);
-      const clearId = setTimeout(() => setToast(null), 4000);
-      return () => {
-        clearTimeout(displayId);
-        clearTimeout(clearId);
-      };
+      setToast(msg);
+      const id = setTimeout(() => setToast(null), 4000);
+      return () => clearTimeout(id);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- add change detection to run CI only for touched areas
- split lint, typecheck, component, integration, and docker scan jobs by domain
- add dedicated lint:ci scripts so CI does not auto-fix files

## Impact
- faster and more isolated CI execution
- clearer failure ownership per application area
- safer lint execution in the pipeline