### PR TITLE
feat(auth): add five refined authentication user stories

### DIFF
--- a/frontend/docs/HU-AUTH-01_registro-usuario.md
+++ b/frontend/docs/HU-AUTH-01_registro-usuario.md
@@ -1,0 +1,66 @@
+# HU-AUTH-01: Registro de usuario
+
+**ID:** HU-AUTH-01  
+**Módulo:** Autenticación  
+**Prioridad:** Alta  
+**Versión:** 1.0
+
+---
+
+## Descripción
+
+Como **usuario nuevo**, quiero registrarme en el sistema ingresando mi nombre, correo electrónico, contraseña y perfil, para poder acceder a las secciones internas de la plataforma.
+
+---
+
+## Criterios de aceptación
+
+- El formulario de registro solicita los siguientes datos: nombre completo, correo electrónico, contraseña y perfil (administrador o empleado).
+- El sistema no permite continuar si alguno de los campos está vacío; en ese caso muestra un aviso indicando qué campo falta por completar.
+- La contraseña debe tener al menos 8 caracteres e incluir una letra mayúscula, una letra minúscula, un número y un carácter especial. Si no cumple alguno de estos requisitos, el sistema informa al usuario qué regla no se ha cumplido.
+- Si el correo ingresado ya pertenece a una cuenta existente, el sistema informa que ese correo ya está registrado y no crea una cuenta duplicada.
+- Al completar el registro correctamente, el sistema muestra un mensaje confirmando que la cuenta fue creada y lleva al usuario a la pantalla de inicio de sesión.
+- Toda la información ingresada es verificada y saneada por el sistema antes de ser procesada.
+
+---
+
+## Reglas de negocio
+
+- El correo electrónico debe ser único dentro del sistema; no se permiten cuentas con el mismo correo.
+- Los perfiles disponibles al momento del registro son: **administrador** y **empleado**.
+- La pantalla de registro es pública; cualquier persona puede acceder a ella sin haber iniciado sesión.
+- Tras un registro exitoso, el usuario debe iniciar sesión manualmente; el sistema no inicia la sesión de forma automática.
+
+---
+
+## Flujo principal
+
+1. La persona accede a la pantalla de registro.
+2. Completa el formulario con nombre, correo, contraseña y perfil.
+3. Envía el formulario.
+4. El sistema valida los datos ingresados.
+5. Si todo es correcto, el sistema crea la cuenta y muestra confirmación.
+6. El sistema lleva al usuario a la pantalla de inicio de sesión.
+
+---
+
+## Flujos alternos
+
+| Situación | Respuesta del sistema |
+| :--- | :--- |
+| Algún campo está vacío | Muestra aviso indicando el campo faltante y no envía el formulario |
+| La contraseña no cumple las reglas | Informa qué requisito no se cumplió |
+| El correo ya existe | Informa que el correo ya está registrado y no crea la cuenta |
+
+---
+
+## Escenarios de validación
+
+| ID | Escenario | Resultado esperado |
+| :--- | :--- | :--- |
+| CA-AUTH-01-01 | Registro con todos los datos válidos | Cuenta creada; se confirma y se dirige al inicio de sesión |
+| CA-AUTH-01-02 | Envío con campos vacíos | El sistema no procesa el registro |
+| CA-AUTH-01-03 | Contraseña sin mayúscula | Se informa el requisito incumplido |
+| CA-AUTH-01-04 | Contraseña de menos de 8 caracteres | Se informa el requisito de longitud mínima |
+| CA-AUTH-01-05 | Correo ya registrado en el sistema | Se informa que el correo ya existe |
+| CA-AUTH-01-06 | Registro exitoso redirige al ingreso | El usuario es llevado a la pantalla de inicio de sesión |

--- a/frontend/docs/HU-AUTH-02_inicio-sesion.md
+++ b/frontend/docs/HU-AUTH-02_inicio-sesion.md
@@ -1,0 +1,63 @@
+# HU-AUTH-02: Inicio de sesión
+
+**ID:** HU-AUTH-02  
+**Módulo:** Autenticación  
+**Prioridad:** Alta  
+**Versión:** 1.0
+
+---
+
+## Descripción
+
+Como **usuario registrado**, quiero iniciar sesión con mi correo electrónico y contraseña, para acceder al panel principal y a las demás secciones internas de la plataforma.
+
+---
+
+## Criterios de aceptación
+
+- El formulario de inicio de sesión solicita correo electrónico y contraseña.
+- El sistema no permite continuar si alguno de los dos campos está vacío.
+- Al ingresar credenciales correctas, el usuario accede al panel principal y su sesión queda activa.
+- Si las credenciales son incorrectas, el sistema informa el error sin redirigir al usuario a otra pantalla.
+- Si el usuario llega a esta pantalla inmediatamente después de haber creado su cuenta, ve un mensaje de bienvenida confirmando la creación exitosa de su cuenta.
+- El mensaje de bienvenida desaparece automáticamente transcurridos 4 segundos y no vuelve a aparecer si el usuario recarga la página.
+- La pantalla de inicio de sesión es pública y accesible sin necesidad de haber ingresado previamente.
+
+---
+
+## Reglas de negocio
+
+- El sistema no indica si el error corresponde al correo o a la contraseña; muestra un mensaje genérico de credenciales incorrectas para proteger la información de los usuarios.
+- Una sesión activa permite al usuario navegar por las secciones internas sin necesidad de autenticarse de nuevo hasta que la sesión expire o se cierre manualmente.
+
+---
+
+## Flujo principal
+
+1. El usuario accede a la pantalla de inicio de sesión.
+2. Ingresa su correo electrónico y contraseña.
+3. Envía el formulario.
+4. El sistema verifica las credenciales.
+5. Si son correctas, el usuario es llevado al panel principal con su sesión activa.
+
+---
+
+## Flujos alternos
+
+| Situación | Respuesta del sistema |
+| :--- | :--- |
+| Algún campo está vacío | No se procesa el ingreso |
+| Credenciales incorrectas | Se muestra mensaje de error; el usuario permanece en la pantalla |
+| Usuario viene de un registro exitoso | Se muestra mensaje de bienvenida que desaparece a los 4 segundos |
+
+---
+
+## Escenarios de validación
+
+| ID | Escenario | Resultado esperado |
+| :--- | :--- | :--- |
+| CA-AUTH-02-01 | Credenciales correctas | El usuario accede al panel principal |
+| CA-AUTH-02-02 | Credenciales incorrectas | Se muestra mensaje de error |
+| CA-AUTH-02-03 | Campos vacíos al enviar | El sistema no procesa el ingreso |
+| CA-AUTH-02-04 | Usuario viene de registro exitoso | Se muestra mensaje de bienvenida |
+| CA-AUTH-02-05 | Mensaje de bienvenida tras 4 segundos | El mensaje desaparece automáticamente |

--- a/frontend/docs/HU-AUTH-03_proteccion-acceso.md
+++ b/frontend/docs/HU-AUTH-03_proteccion-acceso.md
@@ -1,0 +1,63 @@
+# HU-AUTH-03: Protección de acceso por sesión y perfil
+
+**ID:** HU-AUTH-03  
+**Módulo:** Autenticación  
+**Prioridad:** Alta  
+**Versión:** 1.0
+
+---
+
+## Descripción
+
+Como **sistema**, quiero proteger automáticamente las secciones internas para que solo puedan ser accedidas por personas que hayan iniciado sesión y cuenten con el perfil adecuado, evitando el ingreso de personas no autorizadas.
+
+---
+
+## Criterios de aceptación
+
+- Una persona que no ha iniciado sesión y accede a una sección protegida es redirigida automáticamente a la pantalla de inicio de sesión, sin poder ver el contenido restringido.
+- Mientras el sistema verifica si el usuario tiene una sesión activa, no se muestra ningún contenido restringido.
+- Un usuario que ha iniciado sesión pero no tiene el perfil requerido para una sección específica es enviado a una zona que sí le corresponde, sin poder ver el contenido no autorizado.
+- Un usuario con sesión activa y el perfil correcto accede sin interrupciones al contenido de la sección.
+- El menú de navegación superior solo aparece cuando el usuario ha iniciado sesión; en las pantallas públicas no se muestra.
+
+---
+
+## Reglas de negocio
+
+- Las secciones protegidas son: el **panel principal** y el **módulo de registro de turnos**.
+- Las secciones públicas son: la **pantalla de turnos en espera**, el **registro de cuenta** y el **inicio de sesión**.
+- Ambos perfiles (administrador y empleado) tienen acceso a las mismas secciones protegidas en esta versión del sistema.
+- La verificación de acceso ocurre tanto al intentar ingresar directamente por URL como al navegar dentro de la aplicación.
+
+---
+
+## Flujo principal
+
+1. El usuario intenta acceder a una sección protegida.
+2. El sistema verifica si existe una sesión activa.
+3. Si la sesión es válida, verifica el perfil del usuario.
+4. Si el perfil es el adecuado, permite el acceso al contenido.
+
+---
+
+## Flujos alternos
+
+| Situación | Respuesta del sistema |
+| :--- | :--- |
+| Sin sesión activa | Redirige a la pantalla de inicio de sesión |
+| Sesión en proceso de verificación | No muestra contenido restringido mientras valida |
+| Sesión activa pero perfil no permitido | Redirige a una zona accesible para ese perfil |
+| Sesión activa y perfil correcto | Permite el acceso sin interrupciones |
+
+---
+
+## Escenarios de validación
+
+| ID | Escenario | Resultado esperado |
+| :--- | :--- | :--- |
+| CA-AUTH-03-01 | Acceso sin sesión a sección protegida | Redirección a pantalla de inicio de sesión |
+| CA-AUTH-03-02 | Verificación de sesión en curso | No se muestra contenido restringido |
+| CA-AUTH-03-03 | Sesión activa con perfil insuficiente | Redirección a zona permitida |
+| CA-AUTH-03-04 | Sesión activa con perfil correcto | Contenido visible sin interrupciones |
+| CA-AUTH-03-05 | Menú de navegación sin sesión | El menú no aparece en pantallas públicas |

--- a/frontend/docs/HU-AUTH-04_restauracion-sesion.md
+++ b/frontend/docs/HU-AUTH-04_restauracion-sesion.md
@@ -1,0 +1,57 @@
+# HU-AUTH-04: Restauración de sesión
+
+**ID:** HU-AUTH-04  
+**Módulo:** Autenticación  
+**Prioridad:** Media  
+**Versión:** 1.0
+
+---
+
+## Descripción
+
+Como **usuario autenticado**, quiero que al recargar o volver a abrir la aplicación mi sesión se restaure automáticamente, para no tener que iniciar sesión cada vez que regreso al sistema.
+
+---
+
+## Criterios de aceptación
+
+- Al recargar la página o volver a la aplicación, el sistema verifica automáticamente si existe una sesión activa sin que el usuario tenga que hacer nada.
+- Si la sesión sigue siendo válida, el usuario permanece autenticado y puede continuar usando la aplicación sin interrupciones.
+- Si la sesión expiró o no existe, el sistema trata al usuario como no autenticado y le solicita que inicie sesión nuevamente.
+- Durante la verificación inicial de la sesión, el sistema no muestra ni oculta contenido de forma abrupta; mantiene una transición visible y controlada.
+
+---
+
+## Reglas de negocio
+
+- La duración de la sesión es definida por el sistema; el usuario no puede extenderla manualmente.
+- Una sesión restaurada tiene exactamente los mismos permisos y perfil que tenía cuando el usuario cerró o recargó la aplicación.
+- Si la sesión expira mientras el usuario está navegando, el sistema le solicitará autenticarse nuevamente al intentar cualquier acción que requiera sesión activa.
+
+---
+
+## Flujo principal
+
+1. El usuario regresa a la aplicación (recarga o reabre el navegador).
+2. El sistema verifica silenciosamente si existe una sesión activa.
+3. Si la sesión es válida, el usuario continúa sin interrupciones.
+
+---
+
+## Flujos alternos
+
+| Situación | Respuesta del sistema |
+| :--- | :--- |
+| Sesión aún válida al recargar | El usuario permanece autenticado |
+| Sesión expirada o inexistente | El usuario es tratado como no autenticado |
+| Sesión expira durante la navegación | Al intentar acceder a una sección protegida, se solicita nuevo inicio de sesión |
+
+---
+
+## Escenarios de validación
+
+| ID | Escenario | Resultado esperado |
+| :--- | :--- | :--- |
+| CA-AUTH-04-01 | Recarga con sesión válida | El usuario permanece autenticado |
+| CA-AUTH-04-02 | Recarga sin sesión o con sesión expirada | El usuario debe iniciar sesión nuevamente |
+| CA-AUTH-04-03 | Verificación inicial de sesión | No se muestra contenido restringido durante la verificación |

--- a/frontend/docs/HU-AUTH-05_cierre-sesion.md
+++ b/frontend/docs/HU-AUTH-05_cierre-sesion.md
@@ -1,0 +1,55 @@
+# HU-AUTH-05: Cierre de sesión
+
+**ID:** HU-AUTH-05  
+**Módulo:** Autenticación  
+**Prioridad:** Media  
+**Versión:** 1.0
+
+---
+
+## Descripción
+
+Como **usuario autenticado**, quiero poder cerrar mi sesión desde el menú de navegación, para garantizar que mi acceso quede desactivado cuando ya no estoy usando la aplicación.
+
+---
+
+## Criterios de aceptación
+
+- El menú de navegación superior muestra una opción visible para cerrar sesión cuando el usuario está autenticado.
+- Al presionar la opción de cierre de sesión, el sistema desactiva la sesión activa del usuario de forma inmediata.
+- Tras cerrar la sesión, el usuario es llevado automáticamente a la pantalla de inicio de sesión.
+- Una vez cerrada la sesión, el usuario no puede regresar a secciones protegidas usando el botón "atrás" del navegador; el sistema lo redirige nuevamente al inicio de sesión.
+- El menú de navegación desaparece después del cierre de sesión.
+
+---
+
+## Reglas de negocio
+
+- El cierre de sesión es irreversible; para volver a ingresar el usuario debe autenticarse nuevamente.
+- La opción de cerrar sesión solo está disponible para usuarios con sesión activa.
+
+---
+
+## Flujo principal
+
+1. El usuario autenticado presiona la opción de cierre de sesión en el menú.
+2. El sistema desactiva la sesión del usuario.
+3. El sistema lleva al usuario a la pantalla de inicio de sesión.
+
+---
+
+## Flujos alternos
+
+| Situación | Respuesta del sistema |
+| :--- | :--- |
+| El usuario intenta volver atrás tras cerrar sesión | El sistema redirige nuevamente a la pantalla de inicio de sesión |
+
+---
+
+## Escenarios de validación
+
+| ID | Escenario | Resultado esperado |
+| :--- | :--- | :--- |
+| CA-AUTH-05-01 | Cierre de sesión exitoso | Sesión desactivada y redirección a inicio de sesión |
+| CA-AUTH-05-02 | Intento de acceso tras cerrar sesión | El sistema redirige a la pantalla de inicio de sesión |
+| CA-AUTH-05-03 | Menú de navegación tras cierre de sesión | El menú no aparece |


### PR DESCRIPTION
## Overview
Add five refined user stories for the authentication module following business language conventions.

## User Stories Added
- **HU-AUTH-01**: User registration with email validation and password complexity rules
- **HU-AUTH-02**: Sign-in with credentials and welcome message display
- **HU-AUTH-03**: Access control based on session status and user profile
- **HU-AUTH-04**: Session restoration on page reload or browser return
- **HU-AUTH-05**: User session logout functionality

## Changes
- All user stories written in business language (non-technical)
- Each HU includes: description, acceptance criteria, business rules, main flow, alternate flows, and validation scenarios
- HU-AUTH-01 includes refinement questions resolved with concrete decisions

## Content Language
- Code and commit messages: English
- User story content: Spanish (business context language)
- All stories follow TEST_PLAN structure and conventions

## Related Issues
Resolves story refinement for authentication module