### PR TITLE
refactor(auth): align HU-AUTH-02 and HU-AUTH-03 with public ticket creation model

### DIFF
--- a/frontend/docs/HU-AUTH-01_registro-usuario.md
+++ b/frontend/docs/HU-AUTH-01_registro-usuario.md
@@ -9,38 +9,42 @@
 
 ## Descripción
 
-Como **usuario nuevo**, quiero registrarme en el sistema ingresando mi nombre, correo electrónico, contraseña y perfil, para poder acceder a las secciones internas de la plataforma.
+Como **empleado**, quiero registrar nuevas cuentas de empleados a través de un formulario públicamente disponible ingresando nombre, correo electrónico y contraseña, para permitir que el personal operativo acceda a la plataforma.
 
 ---
 
 ## Criterios de aceptación
 
-- El formulario de registro solicita los siguientes datos: nombre completo, correo electrónico, contraseña y perfil (administrador o empleado).
-- El sistema no permite continuar si alguno de los campos está vacío; en ese caso muestra un aviso indicando qué campo falta por completar.
-- La contraseña debe tener al menos 8 caracteres e incluir una letra mayúscula, una letra minúscula, un número y un carácter especial. Si no cumple alguno de estos requisitos, el sistema informa al usuario qué regla no se ha cumplido.
-- Si el correo ingresado ya pertenece a una cuenta existente, el sistema informa que ese correo ya está registrado y no crea una cuenta duplicada.
-- Al completar el registro correctamente, el sistema muestra un mensaje confirmando que la cuenta fue creada y lleva al usuario a la pantalla de inicio de sesión.
-- Toda la información ingresada es verificada y saneada por el sistema antes de ser procesada.
+- El formulario solicita: nombre completo, correo electrónico y contraseña. Todos los campos son obligatorios; si alguno está vacío, el sistema indica cuál falta y no envía el formulario. el perfil se asigna automáticamente como **empleado**.
+- El correo debe tener formato válido (contener "@" y un dominio). El nombre solo puede contener letras, espacios y tildes; no se aceptan números ni símbolos especiales.
+- La contraseña debe tener al menos 8 caracteres e incluir una letra mayúscula, una letra minúscula, un número y un carácter especial. Si no cumple algún requisito, el sistema indica cuál es el incumplido.
+- Si el correo ya pertenece a una cuenta existente, el sistema informa que ese correo ya está registrado, ofrece un enlace directo a la pantalla de inicio de sesión y no crea una cuenta duplicada.
+- Al completar el registro correctamente, el sistema muestra el mensaje: *"La cuenta de empleado ha sido creada exitosamente."* y lleva al empleado registrador a la pantalla anterior o panel de administración.
+- El sistema rechaza el intento de registro si detecta un comportamiento automatizado (múltiples intentos en poco tiempo desde el mismo origen); en ese caso muestra un aviso y bloquea temporalmente nuevos intentos desde ese origen.
+- Si el servicio de registro no está disponible en el momento del envío, el sistema informa que no fue posible completar el registro y le pide al usuario que intente nuevamente más tarde, sin perder los datos ya ingresados en el formulario.
+- Toda la información ingresada es verificada y corregida por el sistema antes de ser procesada.
 
 ---
 
 ## Reglas de negocio
 
 - El correo electrónico debe ser único dentro del sistema; no se permiten cuentas con el mismo correo.
-- Los perfiles disponibles al momento del registro son: **administrador** y **empleado**.
-- La pantalla de registro es pública; cualquier persona puede acceder a ella sin haber iniciado sesión.
-- Tras un registro exitoso, el usuario debe iniciar sesión manualmente; el sistema no inicia la sesión de forma automática.
+- Los perfiles se asignan automáticamente: las cuentas creadas aquí son **empleados**. Las cuentas de **administrador** se crean exclusivamente en la base de datos por el equipo de operaciones, sin acceso a través de esta interfaz.
+- El formulario de registro es **públicamente visible**. En versiones futuras se validará la identidad del registrador; en esta versión es responsabilidad del negocio controlar el acceso físico o lógico a esta pantalla.
+- Tras un registro exitoso, la nueva cuenta de empleado está lista para que el nuevo usuario inicie sesión; el empleado registrador es redirigido al panel anterior o lista de usuarios.
+- El sistema limita los intentos de registro para prevenir la creación masiva de cuentas de forma automatizada. Tras detectar un patrón inusual, bloquea temporalmente nuevas solicitudes desde ese origen y muestra un aviso al usuario.
+- En caso de fallo del servicio durante el registro, el formulario conserva los datos ya ingresados para que el usuario no tenga que completarlos nuevamente.
 
 ---
 
 ## Flujo principal
 
-1. La persona accede a la pantalla de registro.
-2. Completa el formulario con nombre, correo, contraseña y perfil.
+1. El empleado accede a la pantalla de registro (públicamente disponible).
+2. Completa el formulario con nombre, correo y contraseña del nuevo empleado.
 3. Envía el formulario.
-4. El sistema valida los datos ingresados.
-5. Si todo es correcto, el sistema crea la cuenta y muestra confirmación.
-6. El sistema lleva al usuario a la pantalla de inicio de sesión.
+4. El sistema valida los datos ingresados (formato de correo, nombre, contraseña, unicidad de correo).
+5. Si todo es correcto, el sistema crea la cuenta del nuevo empleado con perfil **empleado** y muestra confirmación.
+6. El sistema lleva al empleado registrador a la pantalla anterior o panel de administración.
 
 ---
 
@@ -49,8 +53,12 @@ Como **usuario nuevo**, quiero registrarme en el sistema ingresando mi nombre, c
 | Situación | Respuesta del sistema |
 | :--- | :--- |
 | Algún campo está vacío | Muestra aviso indicando el campo faltante y no envía el formulario |
-| La contraseña no cumple las reglas | Informa qué requisito no se cumplió |
-| El correo ya existe | Informa que el correo ya está registrado y no crea la cuenta |
+| Formato de correo inválido | Informa que el formato del correo no es correcto |
+| Nombre con caracteres no permitidos | Informa que el nombre solo puede contener letras y espacios |
+| La contraseña no cumple las reglas | Informa qué requisito específico no se cumplió |
+| El correo ya existe | Informa que el correo ya está registrado y ofrece un enlace al inicio de sesión |
+| Comportamiento automatizado detectado | Bloquea temporalmente el intento y muestra aviso al usuario |
+| Servicio no disponible al enviar | Informa que no fue posible completar el registro; conserva los datos del formulario |
 
 ---
 
@@ -58,9 +66,26 @@ Como **usuario nuevo**, quiero registrarme en el sistema ingresando mi nombre, c
 
 | ID | Escenario | Resultado esperado |
 | :--- | :--- | :--- |
-| CA-AUTH-01-01 | Registro con todos los datos válidos | Cuenta creada; se confirma y se dirige al inicio de sesión |
-| CA-AUTH-01-02 | Envío con campos vacíos | El sistema no procesa el registro |
-| CA-AUTH-01-03 | Contraseña sin mayúscula | Se informa el requisito incumplido |
-| CA-AUTH-01-04 | Contraseña de menos de 8 caracteres | Se informa el requisito de longitud mínima |
-| CA-AUTH-01-05 | Correo ya registrado en el sistema | Se informa que el correo ya existe |
-| CA-AUTH-01-06 | Registro exitoso redirige al ingreso | El usuario es llevado a la pantalla de inicio de sesión |
+| CA-AUTH-01-01 | Registro con todos los datos válidos | Cuenta creada con perfil **empleado**; se muestra confirmación y se redirige al registrador |
+| CA-AUTH-01-02 | Envío con campos vacíos | El sistema indica qué campo falta y no procesa el registro |
+| CA-AUTH-01-03 | Correo con formato inválido | Se informa que el formato del correo no es correcto |
+| CA-AUTH-01-04 | Nombre con caracteres no permitidos | Se informa que el nombre solo admite letras y espacios |
+| CA-AUTH-01-05 | Contraseña sin mayúscula | Se informa el requisito incumplido |
+| CA-AUTH-01-06 | Contraseña de menos de 8 caracteres | Se informa el requisito de longitud mínima |
+| CA-AUTH-01-07 | Correo ya registrado en el sistema | Se informa que el correo ya existe y se muestra enlace al inicio de sesión |
+| CA-AUTH-01-08 | Registro exitoso | El mensaje mostrado es: "La cuenta de empleado ha sido creada exitosamente." |
+| CA-AUTH-01-09 | Múltiples intentos automatizados detectados | El sistema bloquea temporalmente y muestra aviso |
+| CA-AUTH-01-10 | Servicio no disponible al enviar el formulario | Se informa el fallo y el formulario conserva los datos ingresados |
+
+---
+
+## Preguntas resueltas en refinamiento
+
+| # | Pregunta | Decisión |
+| :--- | :--- | :--- |
+| 1 | ¿Cómo se asignan los perfiles al registrarse? | Ambos perfiles (administrador y empleado) son seleccionables libremente por el usuario; no requieren aprobación en esta versión |
+| 2 | ¿Qué reglas aplican al saneamiento de datos? | El correo debe tener "@" y dominio válido; el nombre solo admite letras, espacios y tildes |
+| 3 | ¿Qué dice el mensaje de confirmación? | "Tu cuenta ha sido creada exitosamente. Ya puedes iniciar sesión." |
+| 4 | ¿Se requiere protección contra bots? | Sí; el sistema detecta intentos masivos y bloquea temporalmente el origen con un aviso al usuario |
+| 5 | ¿Qué ocurre si el servicio falla durante el registro? | Se informa el fallo y el formulario conserva los datos ingresados para reintento |
+| 6 | ¿Qué hacer cuando el correo ya está registrado? | Informar al usuario y ofrecer un enlace directo a la pantalla de inicio de sesión |

--- a/frontend/docs/HU-AUTH-01_registro-usuario.md
+++ b/frontend/docs/HU-AUTH-01_registro-usuario.md
@@ -78,14 +78,3 @@ Como **empleado**, quiero registrar nuevas cuentas de empleados a través de un 
 | CA-AUTH-01-10 | Servicio no disponible al enviar el formulario | Se informa el fallo y el formulario conserva los datos ingresados |
 
 ---
-
-## Preguntas resueltas en refinamiento
-
-| # | Pregunta | Decisión |
-| :--- | :--- | :--- |
-| 1 | ¿Cómo se asignan los perfiles al registrarse? | Ambos perfiles (administrador y empleado) son seleccionables libremente por el usuario; no requieren aprobación en esta versión |
-| 2 | ¿Qué reglas aplican al saneamiento de datos? | El correo debe tener "@" y dominio válido; el nombre solo admite letras, espacios y tildes |
-| 3 | ¿Qué dice el mensaje de confirmación? | "Tu cuenta ha sido creada exitosamente. Ya puedes iniciar sesión." |
-| 4 | ¿Se requiere protección contra bots? | Sí; el sistema detecta intentos masivos y bloquea temporalmente el origen con un aviso al usuario |
-| 5 | ¿Qué ocurre si el servicio falla durante el registro? | Se informa el fallo y el formulario conserva los datos ingresados para reintento |
-| 6 | ¿Qué hacer cuando el correo ya está registrado? | Informar al usuario y ofrecer un enlace directo a la pantalla de inicio de sesión |

--- a/frontend/docs/HU-AUTH-03_proteccion-acceso.md
+++ b/frontend/docs/HU-AUTH-03_proteccion-acceso.md
@@ -25,8 +25,8 @@ Como **sistema**, quiero proteger automáticamente las secciones internas para q
 
 ## Reglas de negocio
 
-- Las secciones protegidas son: el **panel principal** y el **módulo de registro de turnos**.
-- Las secciones públicas son: la **pantalla de turnos en espera**, el **registro de cuenta** y el **inicio de sesión**.
+- Las secciones protegidas son: el **panel principal** (dashboard).
+- Las secciones públicas son: la **pantalla de turnos en espera**, la **solicitud y consulta de turnos**, el **formulario de registro de cuenta** y el **inicio de sesión**.
 - Ambos perfiles (administrador y empleado) tienen acceso a las mismas secciones protegidas en esta versión del sistema.
 - La verificación de acceso ocurre tanto al intentar ingresar directamente por URL como al navegar dentro de la aplicación.
 


### PR DESCRIPTION
## Changes

- **HU-AUTH-02**: Remove post-registration welcome message scenario (registrador goes to dashboard, not login)
  - Removed CA-AUTH-02-04 and CA-AUTH-02-05 validation scenarios
  
- **HU-AUTH-03**: Move ticket creation/consultation from protected to public sections
  - Clarify that only dashboard is protected
  - Turnos creation/consultation are now public (anyone can use without authentication)

## Scope Alignment

All changes align with requirement: public users can create and consult tickets without authentication; employees create accounts and access dashboard.