### PR TITLE
fix(producer): remove @types/helmet incompatible with helmet v8

### DIFF
--- a/backend/producer/bun.lock
+++ b/backend/producer/bun.lock
@@ -30,7 +30,6 @@
         "@nestjs/schematics": "^10.2.3",
         "@nestjs/testing": "^10.4.22",
         "@types/express": "^4.17.25",
-        "@types/helmet": "^4.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.19.37",
         "@types/supertest": "^6.0.3",
@@ -323,8 +322,6 @@
     "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
-
-    "@types/helmet": ["@types/helmet@4.0.0", "", { "dependencies": { "helmet": "*" } }, "sha512-ONIn/nSNQA57yRge3oaMQESef/6QhoeX7llWeDli0UZIfz8TQMkfNPTXA8VnnyeA1WUjG2pGqdjEIueYonMdfQ=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 

--- a/backend/producer/package.json
+++ b/backend/producer/package.json
@@ -46,7 +46,6 @@
         "@nestjs/schematics": "^10.2.3",
         "@nestjs/testing": "^10.4.22",
         "@types/express": "^4.17.25",
-        "@types/helmet": "^4.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.19.37",
         "@types/supertest": "^6.0.3",


### PR DESCRIPTION
## Problem

`@types/helmet@4.0.0` conflicts with `helmet@8.x` which ships its own bundled TypeScript declarations. This caused a TypeScript compile error at startup:

```
src/main.ts:6:20 - error TS2307: Cannot find module 'helmet' or its corresponding type declarations.
```

## Root Cause

`@types/helmet` was designed for helmet v4. Starting from helmet v5+, the package includes its own `index.d.ts`. Having both packages installed causes TypeScript module resolution to break.

## Fix

- Removed `@types/helmet` from `devDependencies` in `package.json`
- Removed `@types/helmet` entry from `bun.lock`

## Testing

Container starts successfully with `docker compose up --build producer` — no TypeScript errors.